### PR TITLE
Update jquery to 3.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 ```html
 <body>
     ...
-    <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sgds-govtech@1.3.14/js/sgds.js"></script>
     ...
 </body>
@@ -95,7 +95,7 @@ Test out the latest development build:
 <link rel="stylesheet" href="https://dev.designsystem.gov.sg/css/sgds.css"/>
 
 <!-- JS in <body> -->
-<script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
 <script src="https://dev.designsystem.gov.sg/js/sgds.js"></script>
 ```
 

--- a/_includes/admin-template/script.html
+++ b/_includes/admin-template/script.html
@@ -1,4 +1,4 @@
-<script src="https://code.jquery.com/jquery-3.4.1.min.js"
+<script src="https://code.jquery.com/jquery-3.5.1.min.js"
         integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
 <script src="/assets/js/admin-template/Chart.bundle.js"></script>
 <script src="/assets/js/admin-template/charts.js"></script>

--- a/_includes/import-scripts.html
+++ b/_includes/import-scripts.html
@@ -1,8 +1,7 @@
 <script
-    src="https://code.jquery.com/jquery-3.4.1.min.js"
-    integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
-    crossorigin="anonymous"
-></script>
+  src="https://code.jquery.com/jquery-3.5.1.min.js"
+  integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
+  crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/css-element-queries@1.2.0/src/ResizeSensor.js"></script>
 <script src="/js/sgds.js"></script>
 <script src="/apps/build/main.js"></script>

--- a/contents/docs/installation.html
+++ b/contents/docs/installation.html
@@ -33,7 +33,7 @@ permalink: /docs/installation/
 <body>
     ...
     <!-- Make sure jQuery is loaded before sgds.js -->
-    <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
 
     <!-- jsDelivr -->
     <script src="https://cdn.jsdelivr.net/npm/sgds-govtech@{{ site.sgds-version }}/js/sgds.js"></script>
@@ -134,7 +134,7 @@ import "sgds-govtech/js/sgds"; // Do not use with other web frameworks!
 <body>
     ...
     <!-- Make sure jQuery is included before sgds.js -->
-    <script src="/my/static/files/jquery-3.4.1.min.js"></script>
+    <script src="/my/static/files/jquery-3.5.1.min.js"></script>
     <script src="/my/static/files/js/sgds.js"></script>
 </body>
 {%- endhighlight -%}


### PR DESCRIPTION
# Description
Update jQuery from 3.4.1 to 3.5.1
[See jQuery Vulnerability](https://snyk.io/vuln/npm:jquery)

Please check on the checkbox for those that are relevant (put x between the brackets)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Code enhancement and update (non-breaking change)
- [ ] Security patch
