### PR TITLE
fix: broken placeholder image url

### DIFF
--- a/collections/_general/modal.html
+++ b/collections/_general/modal.html
@@ -32,7 +32,7 @@ category: General
 <div class="sgds-modal" id="image-modal" aria-label="Image caption here" role="dialog">
     <div class="sgds-modal-background"></div>
     <div class="sgds-modal-content">
-        <img src="https://placehold.it/1280x720/" alt="placeholder image">
+        <img src="https://via.placeholder.com/1280x720.png" alt="placeholder image">
     </div>
     <button class="sgds-modal-close is-large" aria-label="close"></button>
 </div>


### PR DESCRIPTION
# Description

fixed broken placeholder image url in modal example

## Type of change

Please check on the checkbox for those that are relevant (put x between the brackets)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code enhancement and update (non-breaking change)
- [ ] Security patch

## How Has This Been Tested?

- Example is now work as usual.