### PR TITLE
fix(modal): account for icon in modal title

### DIFF
--- a/sgds/sass/sgds-theme/components/_modal.scss
+++ b/sgds/sass/sgds-theme/components/_modal.scss
@@ -1,6 +1,9 @@
 @import "../../bootstrap/modal";
 .sgds{
     &.modal{
+        .modal-header > i {
+            margin-right: 16px;
+        }
         .modal-footer{
             padding-top:0;
         }
@@ -32,6 +35,7 @@
                 flex-grow: 1;
                 flex-flow: column;
                 justify-content: center;
+                margin-left: 36px;
                 
             }
             .modal-footer{


### PR DESCRIPTION

Fixes # (issue number)

icon and text in .modal-title too close 
<img width="501" alt="Screenshot 2022-06-08 at 5 35 35 PM" src="https://user-images.githubusercontent.com/55618945/172584577-dd08c753-a827-4e15-b3fa-127972282bcc.png">

after fix. Add 16px margin-right
<img width="501" alt="Screenshot 2022-06-08 at 5 37 25 PM" src="https://user-images.githubusercontent.com/55618945/172584896-fa7046aa-f987-44d9-9610-6791994cd8b1.png">


centered-align-variant with close button is off center
<img width="501" alt="Screenshot 2022-06-08 at 5 48 03 PM" src="https://user-images.githubusercontent.com/55618945/172587278-b9932daa-47e8-48a1-bf25-42b99153dd3b.png">


fix by adding margin-left: 36px (offset the size of 36px closebutton) 
<img width="501" alt="Screenshot 2022-06-08 at 5 46 20 PM" src="https://user-images.githubusercontent.com/55618945/172587296-20c80415-8640-415e-833f-c9d4f5d14c4e.png">

