### PR TITLE
Gh action publish master for --latest tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     branches:
-      - ghAction-publish-master
+      - master
 
 jobs:
   publish:    
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: '2.6' # Version range or exact version of a Ruby version to use, using semvers version range syntax.
+          ruby-version: '2.6'
       - run: |
           gem install bundler
           bundle install
@@ -23,10 +23,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build:lib
-      # - name: Version Check
-      #   uses: EndBug/version-check@v2.1.0
-      #   id: check
+      - name: Version Check
+        uses: EndBug/version-check@v2.1.0
+        id: check
       - run: npm publish --tag latest --access public
-        # if: steps.check.outputs.changed == 'true'
+        if: steps.check.outputs.changed == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - ghAction-publish-master
+
+jobs:
+  publish:    
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.6' # Version range or exact version of a Ruby version to use, using semvers version range syntax.
+      - run: |
+          gem install bundler
+          bundle install
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build:lib
+      # - name: Version Check
+      #   uses: EndBug/version-check@v2.1.0
+      #   id: check
+      - run: npm publish --tag latest --access public
+        # if: steps.check.outputs.changed == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "sgds-govtech",
+  "name": "@govtechsg/sgds",
   "version": "1.3.23",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@govtechsg/sgds-govtech",
+  "name": "@govtechsg/sgds",
   "version": "1.3.23",
   "description": "Design System unites Singapore Government digital services around a common visual language and user experience",
   "repository": {


### PR DESCRIPTION
# Description

@govtechsg/sgds 1.3.23 published
Added github actions with version checking to run on master. Since 1.3.23 is already published, npm publish step wont run on master unless the version number is changed

Fixes # (issue number)

## Type of change

Please check on the checkbox for those that are relevant (put x between the brackets)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code enhancement and update (non-breaking change)
- [ ] Security patch

## How Has This Been Tested?

Please describe or list the test cases that you ran to verify your changes, and provide instructions so we can reproduce them. 
