### PR TITLE
fix(template): shift media query into .with-sidenav selector

### DIFF
--- a/sass/_templates.scss
+++ b/sass/_templates.scss
@@ -1,6 +1,5 @@
 sgds-template-grid {
     background: #fafafa;
-
     &.with-sidenav {
         display: grid;
         grid-template-columns: 15rem minmax(min-content, 1fr);
@@ -8,14 +7,15 @@ sgds-template-grid {
         &.with-toc {
             grid-template-columns: 15rem minmax(min-content, 1fr) 15rem;
         }
-    }
-    @include media-breakpoint-down(lg) {
-        display: block;
-        sgds-aside-area,
-        aside {
-            display: none;
+        @include media-breakpoint-down(lg) {
+            display: block;
+            sgds-aside-area,
+            aside {
+                display: none;
+            }
         }
     }
+
 }
 
 sgds-aside-area {


### PR DESCRIPTION
# Description

**Grid layout remains when mediawidth drops below lg**

Fixes # (issue number)

**Fixes responsiveness of templates.**


## Type of change

Please check on the checkbox for those that are relevant (put x between the brackets)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code enhancement and update (non-breaking change)
- [ ] Security patch

## How Has This Been Tested?

Tested on the templates ui page