### PR TITLE
build(*): removing the sgds prefix for git tag [skip-cd]

### DIFF
--- a/lib/sgds/.npmrc
+++ b/lib/sgds/.npmrc
@@ -1,1 +1,1 @@
-tag-version-prefix = "sgds/v"
+tag-version-prefix = "v"

--- a/lib/sgds/CHANGELOG.md
+++ b/lib/sgds/CHANGELOG.md
@@ -1,3 +1,22 @@
+## Unreleased
+
+## v2.3.0 (2024-05-02)
+
+### Feat
+
+- **sidenav**: add sticky and small refactor to mimick 5.3 [skip-cd] (#480)
+
+### Fix
+
+- **portal**: rename home page grid css selector
+- *****: update gem and bundle and fixing custom-style WIP
+- **docs**: typo in footer (#474)
+- **docs**: typo in footer
+
+### Refactor
+
+- **home**: make npm version dynamic in home page
+
 ## v2.2.0 (2023-01-09)
 
 ### Feat

--- a/lib/sgds/package.json
+++ b/lib/sgds/package.json
@@ -15,7 +15,8 @@
   ],
   "scripts": {
     "build": "rm -rf ./css && webpack --mode=production",
-    "dev": "webpack --watch"
+    "dev": "webpack --watch",
+    "changelog": "cz changelog --incremental"
   },
   "devDependencies": {
     "concurrently": "^7.0.0",


### PR DESCRIPTION
# Description

Commitizen generating changelog  still does not recognize git tags that are of non semver. so sgds/v2.3.0 will be flagged as Invalid GitTag version. 

Since we won't be publishing sgds-x-family anymore. no reason to keep the sgds/ prefix. 

Folder structure to be revised in future.. 


Fixes # (issue number)

## Type of change

Please check on the checkbox for those that are relevant (put x between the brackets)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code enhancement and update (non-breaking change)
- [ ] Security patch

## How Has This Been Tested?

Please describe or list the test cases that you ran to verify your changes, and provide instructions so we can reproduce them. 
