### PR TITLE
fix(variables): mistake in enable cssgrid to true by accident [skip-cd]

### DIFF
--- a/lib/sgds/sass/_variables.scss
+++ b/lib/sgds/sass/_variables.scss
@@ -399,7 +399,7 @@ $enable-transitions: true !default;
 $enable-reduced-motion: true !default;
 $enable-smooth-scroll: true !default;
 $enable-grid-classes: true !default;
-$enable-cssgrid: true !default;
+$enable-cssgrid: false !default;
 $enable-button-pointers: true !default;
 $enable-rfs: true !default;
 $enable-validation-icons: true !default;


### PR DESCRIPTION
# Description

Fixes # (issue number)

Toggled Bootstrap $enable-css-grid to true by accident while working on portal previously. 
This should be released as a patch 

## Type of change

Please check on the checkbox for those that are relevant (put x between the brackets)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code enhancement and update (non-breaking change)
- [ ] Security patch

## How Has This Been Tested?

Please describe or list the test cases that you ran to verify your changes, and provide instructions so we can reproduce them. 
